### PR TITLE
Make installation instructions clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,17 @@ Flagmatic 2.0
 
 A package for the Sage system.
 
-To install, type:
+To install, first download and enter the `pkg` directory of the download:
 
-    $ cd pkg; sage -python setup.py install
+    $ cd pkg
 
-Then, from the Sage prompt, type:
+Then, assuming the command `sage` is in your `PATH`, type:
+
+    $sage -python setup.py install
+
+(Replace `sage` by whatever you use to start Sage from the command line
+if necessary.)
+
+Finally, to use flagmatic, start Sage and type this in the Sage prompt:
 
     sage: from flagmatic.all import *


### PR DESCRIPTION
The installation instructions crucially assume that one has `sage` in one's `PATH`, which may not be the case.  See also http://stackoverflow.com/questions/27108300/problems-installing-flagmatic/
